### PR TITLE
Remove Line about N in Scenario

### DIFF
--- a/src/Kendrick/KEDeterministicExamples.class.st
+++ b/src/Kendrick/KEDeterministicExamples.class.st
@@ -972,12 +972,12 @@ KEDeterministicExamples >> exampleRK4SolverOnSIRMultiHostModel [
 			c = #reservoir2
 				ifTrue: [ val := 0.05 ].
 			val ].
-	model
+	"model
 		atParameter: #N
 		assignValue: [ :aModel | 
 			| c |
 			c := aModel currentCompartment at: #species.
-			aModel sizeOfPopulation: c ].
+			aModel sizeOfPopulation: c ]."
 	model
 		addParameter: #rho
 		value: [ :aModel | 

--- a/src/Kendrick/KEModel.class.st
+++ b/src/Kendrick/KEModel.class.st
@@ -60,7 +60,11 @@ KEModel >> atCompartment: anObject [
 	key
 		at: #status
 		ifPresent: [ (key at: #status) = #empty
-				ifTrue: [ ^ self atParameter: #N ] ].
+				ifTrue: [ "^ self atParameter: #N"
+					|subpopulation|
+					subpopulation := Dictionary newFrom: (self currentCompartment).
+					subpopulation removeKey: #status.
+					^ self sizeOfPopulation: (subpopulation values) ] ].
 	c := self attributes keys reject: [ :a | key keys includes: a ].
 	c isEmpty
 		ifTrue: [ ^ self population sizeOfACompartment: key ]

--- a/src/Kendrick/KEModelTest.class.st
+++ b/src/Kendrick/KEModelTest.class.st
@@ -363,6 +363,23 @@ KEModelTest >> testSizeOfEachCompartmentSizeOfSIRModel [
 ]
 
 { #category : #tests }
+KEModelTest >> testSizeOfPopulation [
+	|model subpopulation dict|
+	model := KEModel new.
+	model attributes: { #status->#(S I R). #region->#(A B C) }.
+	model atCompartment: { #status->#S. #region->#A } put: 99999 atOthersPut: 0.
+	model atCompartment: { #status->#I. #region->#A } put: 1.
+	
+	model currentCompartment: { #status->#I. #region->#A }.
+	dict := Dictionary newFrom: (model currentCompartment).
+	dict removeKey: #status.
+	subpopulation := dict values.
+	
+	self assert: subpopulation equals: { #A }.
+	self assert: (model sizeOfPopulation: subpopulation) equals: 100000.
+]
+
+{ #category : #tests }
 KEModelTest >> testVerifyNumberOfEquationsOfSumOfTwoConcerns [
 
 	| model model1 multiHostConcern |

--- a/src/Kendrick/KEPopulationTest.class.st
+++ b/src/Kendrick/KEPopulationTest.class.st
@@ -33,6 +33,21 @@ KEPopulationTest >> testRemoveIndividual [
 ]
 
 { #category : #tests }
+KEPopulationTest >> testSizeOfPopulation [
+	|model|
+	model := KEModel new.
+	model attributes: { #status->#(S I R). #region->#(A B C) }.
+	"model initializeCompartments."
+	model atCompartment: { #status->#S. #region->#A } put: 99999 atOthersPut: 0.
+	model atCompartment: { #status->#I. #region->#A } put: 1.
+	
+	self assert: (model population size) equals: 100000.
+	self assert: (model population sizeOfPopulation: {#A}) equals: 100000.
+	self assert: (model population sizeOfPopulation: {#A. #S}) equals: 99999.
+	self assert: (model population sizeOfPopulation: {#S}) equals: 99999.
+]
+
+{ #category : #tests }
 KEPopulationTest >> testSizeOfPopulationIsTheSameThanTheSumOfItsCompartment [
 	| model compartmentSSize compartmentISize compartmentRSize |
 	model := KEModel new attributes:{#status -> #(#S #I #R)}.

--- a/src/Kendrick/KETransitionTest.class.st
+++ b/src/Kendrick/KETransitionTest.class.st
@@ -35,6 +35,41 @@ KETransitionTest >> testEvaluateProbability [
 ]
 
 { #category : #tests }
+KETransitionTest >> testEvaluateProbabilityOfBirthTransition [
+	| tr model prob rate |
+	model := KEModel new.
+	model attributes: {(#status -> #(S I R))}.
+	model atCompartment: {(#status -> #S)} put: 99999 atOthersPut: 0.
+	model atCompartment: {(#status -> #I)} put: 1.
+	model addParameter:  (#mu -> 0.001).
+	tr := KETransition from: {#status -> #empty} to: {#status -> #S} probability: [ :m | (m atParameter: #mu) ].
+	
+	prob := tr probability value: model.
+	model currentCompartment: tr to.
+	rate := prob * (model atCompartment: tr from).
+	self assert: prob equals: 0.001.
+	self assert: rate equals: 100.
+]
+
+{ #category : #tests }
+KETransitionTest >> testEvaluateProbabilityOfBirthTransition2 [
+	| tr model prob rate |
+	model := KEModel new.
+	model attributes: { #status->#(S I R). #region->#(A B C) }.
+	model atCompartment: { #status->#S. #region->#A } put: 99999 atOthersPut: 0.
+	model atCompartment: { #status->#I. #region->#A } put: 1.
+	model addParameter:  (#mu -> 0.001).
+	
+	tr := KETransition from: {#status -> #empty. #region->#A} to: {#status -> #S. #region->#A} probability: [ :m | (m atParameter: #mu) ].
+	
+	prob := tr probability value: model.
+	model currentCompartment: tr to.
+	rate := prob * (model atCompartment: tr from).
+	self assert: prob equals: 0.001.
+	self assert: rate equals: 100.
+]
+
+{ #category : #tests }
 KETransitionTest >> testExecuteTransition [
 	| tr model |
 	tr := KETransition from: {#status -> #S} to: {#status -> #I} probability: [ :f :t :m | (m atParameter: #beta) * f * t ].


### PR DESCRIPTION
1. instead of return model atParameter: #N when calculate the rate of birth event, just use the KEModel>>sizeOfPopulation instead
2. Add some test to make sure every goes well
3. Update Script by remove N, compared with the old version (same result)
4. Remove the code of N in low-level example, compare with previous version (same result)