### PR TITLE
equations2 method 

### DIFF
--- a/src/Kendrick/KEComponent.class.st
+++ b/src/Kendrick/KEComponent.class.st
@@ -134,6 +134,22 @@ KEComponent >> equations [
 	^ equations
 ]
 
+{ #category : #'as yet unclassified' }
+KEComponent >> equations2 [ 
+	|equation |
+	
+	equation := Dictionary new.
+	self finestCompartmentNames do: [ :k | equation at: k put: OrderedCollection new ].
+	
+		self transitions do: [ :tr | 
+		((tr from at: #status) ~= #empty and: [ 
+			 (tr to at: #status) ~= #empty ]) ifTrue: [ 
+			(equation at: tr from) add: (Array with: tr with: -1).
+			(equation at: tr to) add: (Array with: tr with: 1) ] ].
+	
+	^ equation
+]
+
 { #category : #accessing }
 KEComponent >> equationsToTransitions [
 	"This is only working for status ODE equations, not general ODE equations"


### PR DESCRIPTION
At the moment, the `equations2` method works for the `testNumberOfEquationsOfSIRModelIs3` test but not yet for `testSIRMOdelEquationsContainSVariable`.

I'm working out how to make the second test work.