### PR TITLE
Change separateExpression by expand

### DIFF
--- a/src/Kendrick/KEBinaryExpression.class.st
+++ b/src/Kendrick/KEBinaryExpression.class.st
@@ -116,6 +116,48 @@ op = #'^' ifTrue:[
 ]
 
 { #category : #'as yet unclassified' }
+KEBinaryExpression >> expand [
+
+	"This method express an expression as a sum of factors (the reverse of the factorization)."
+
+	| expressions |
+	expressions := OrderedCollection new.
+	leftHandSide isSeparable
+		ifTrue: [ 
+			| l |
+			l := OrderedCollection new.
+			expressions := leftHandSide doSeparation.
+			expressions do: [ :each | 
+				| exp |
+				exp := KEBinaryExpression new
+					       op: op;
+					       leftHandSide: each;
+					       rightHandSide: rightHandSide.
+				exp isSeparable
+					ifTrue: [ l addAll: exp doSeparation ]
+					ifFalse: [ l add: exp ] ].
+			^ l ]
+		ifFalse: [ 
+			rightHandSide isSeparable
+				ifTrue: [ 
+					| l |
+					l := OrderedCollection new.
+					expressions := rightHandSide doSeparation.
+					expressions do: [ :each | 
+						| e |
+						e := KEBinaryExpression new
+							     op: op;
+							     leftHandSide: leftHandSide;
+							     rightHandSide: each.
+						e isSeparable
+							ifTrue: [ l addAll: e doSeparation ]
+							ifFalse: [ l add: e ] ].
+					^ l ]
+				ifFalse: [ expressions := self doSeparation ] ].
+	^ expressions
+]
+
+{ #category : #'as yet unclassified' }
 KEBinaryExpression >> generateEvents [
 
 	| events |
@@ -124,7 +166,7 @@ KEBinaryExpression >> generateEvents [
 		self isSeparable
 			ifTrue: [ 
 				| exprs |
-				exprs := self separateExpression.
+				exprs := self expand.
 				events := exprs collect: [ :each | 
 					          KEEvent new rate: each normalize ] ]
 			ifFalse: [ events add: (KEEvent new rate: self normalize) ] ].
@@ -306,46 +348,6 @@ KEBinaryExpression >> rightHandSide [
 { #category : #accessing }
 KEBinaryExpression >> rightHandSide: anExpression [
 	rightHandSide := anExpression
-]
-
-{ #category : #'as yet unclassified' }
-KEBinaryExpression >> separateExpression [
-
-	| expressions |
-	expressions := OrderedCollection new.
-	leftHandSide isSeparable
-		ifTrue: [ 
-			| l |
-			l := OrderedCollection new.
-			expressions := leftHandSide doSeparation.
-			expressions do: [ :each | 
-				| exp |
-				exp := KEBinaryExpression new
-					       op: op;
-					       leftHandSide: each;
-					       rightHandSide: rightHandSide.
-				exp isSeparable
-					ifTrue: [ l addAll: exp doSeparation ]
-					ifFalse: [ l add: exp ] ].
-			^ l ]
-		ifFalse: [ 
-			rightHandSide isSeparable
-				ifTrue: [ 
-					| l |
-					l := OrderedCollection new.
-					expressions := rightHandSide doSeparation.
-					expressions do: [ :each | 
-						| e |
-						e := KEBinaryExpression new
-							     op: op;
-							     leftHandSide: leftHandSide;
-							     rightHandSide: each.
-						e isSeparable
-							ifTrue: [ l addAll: e doSeparation ]
-							ifFalse: [ l add: e ] ].
-					^ l ]
-				ifFalse: [ expressions := self doSeparation ] ].
-	^ expressions
 ]
 
 { #category : #testing }

--- a/src/Kendrick/KEBinaryExpression.class.st
+++ b/src/Kendrick/KEBinaryExpression.class.st
@@ -120,40 +120,35 @@ KEBinaryExpression >> expand [
 
 	"This method express an expression as a sum of factors (the reverse of the factorization)."
 
-	| expressions |
-	expressions := OrderedCollection new.
+	| expressions ord|
+	expressions := KEExpression new.
+	ord := OrderedCollection new.
 	leftHandSide isSeparable
 		ifTrue: [ 
-			| l |
-			l := OrderedCollection new.
 			expressions := leftHandSide doSeparation.
-			expressions do: [ :each | 
-				| exp |
-				exp := KEBinaryExpression new
+			expressions collect: [ :each | 
+				| lhs |
+				lhs := KEBinaryExpression new
 					       op: op;
 					       leftHandSide: each;
 					       rightHandSide: rightHandSide.
-				exp isSeparable
-					ifTrue: [ l addAll: exp doSeparation ]
-					ifFalse: [ l add: exp ] ].
-			^ l ]
+				lhs isSeparable
+					ifTrue: [ ord  addAll: lhs doSeparation ]
+							ifFalse: [ ord add: lhs ] ].]
 		ifFalse: [ 
 			rightHandSide isSeparable
 				ifTrue: [ 
-					| l |
-					l := OrderedCollection new.
 					expressions := rightHandSide doSeparation.
-					expressions do: [ :each | 
-						| e |
-						e := KEBinaryExpression new
+					expressions collect: [ :each | 
+						| rhs |
+						rhs := KEBinaryExpression new
 							     op: op;
 							     leftHandSide: leftHandSide;
 							     rightHandSide: each.
-						e isSeparable
-							ifTrue: [ l addAll: e doSeparation ]
-							ifFalse: [ l add: e ] ].
-					^ l ]
-				ifFalse: [ expressions := self doSeparation ] ].
+						rhs isSeparable
+							ifTrue: [ ord addAll: rhs doSeparation ]
+							ifFalse: [ ord add: rhs ] ].]
+				ifFalse: [ expressions := self doSeparation ]].
 	^ expressions
 ]
 

--- a/src/Kendrick/KEBinaryExpression.class.st
+++ b/src/Kendrick/KEBinaryExpression.class.st
@@ -126,7 +126,7 @@ KEBinaryExpression >> expand [
 	leftHandSide isSeparable
 		ifTrue: [ 
 			expressions := leftHandSide doSeparation.
-			expressions collect: [ :each | 
+			expressions do: [ :each | 
 				| lhs |
 				lhs := KEBinaryExpression new
 					       op: op;
@@ -139,7 +139,7 @@ KEBinaryExpression >> expand [
 			rightHandSide isSeparable
 				ifTrue: [ 
 					expressions := rightHandSide doSeparation.
-					expressions collect: [ :each | 
+					expressions do: [ :each | 
 						| rhs |
 						rhs := KEBinaryExpression new
 							     op: op;

--- a/src/Kendrick/KEExpressionTest.class.st
+++ b/src/Kendrick/KEExpressionTest.class.st
@@ -362,8 +362,8 @@ KEExpressionTest >> testSeparateABinaryExpression [
 	s2 := 's=-(A+B)*(-C)' parseAsAnEquation.
 	s3 := 's=(-E)*D*F*(A+B)' parseAsAnEquation.
 	s4 := 's=(A+B)*(C+D)' parseAsAnEquation.
-	self assert: 3 equals: s1 expression separateExpression size.
-	self assert: 2 equals: s2 expression separateExpression size.
-	self assert: 2 equals: s3 expression separateExpression size.
-	self assert: 4 equals: s4 expression separateExpression size
+	self assert: 3 equals: s1 expression expand size.
+	self assert: 2 equals: s2 expression expand size.
+	self assert: 2 equals: s3 expression expand size.
+	self assert: 4 equals: s4 expression expand size
 ]


### PR DESCRIPTION
We rename the `separate Expression` method by the `expand` method