### PR TITLE
Verification of the transition number of the basic SIR model with the DSL

### DIFF
--- a/src/Kendrick/DSLExamples.class.st
+++ b/src/Kendrick/DSLExamples.class.st
@@ -41,6 +41,24 @@ DSLExamples >> testAtAttributeOfSIRExample [
 ]
 
 { #category : #tests }
+DSLExamples >> testVerifyAllStatesOfSIRExample [ 
+	<gtExample>
+	|sirExample allStatesOfModel|
+	sirExample := KModel new.
+	sirExample 
+		attribute: #(status -> S I R);
+		parameters: #(beta lambda gamma mu);
+		transitions: #(
+			S -- lambda --> I.
+			I -- gamma --> R.);
+		lambda: #(beta*I/N).
+		
+	allStatesOfModel := #(#S #I #R) asOrderedCollection.
+	self assert: (sirExample atAttribute: #status) equals: allStatesOfModel.
+	^sirExample 
+]
+
+{ #category : #tests }
 DSLExamples >> testVerifyNumberOfTransitionsOfSIRExampleIs2 [ 
 	<gtExample>
 	|sirExample|

--- a/src/Kendrick/DSLExamples.class.st
+++ b/src/Kendrick/DSLExamples.class.st
@@ -39,3 +39,20 @@ DSLExamples >> testAtAttributeOfSIRExample [
 	self assert: (sirExample atAttribute: #status) size equals: 3.
 	^sirExample 
 ]
+
+{ #category : #tests }
+DSLExamples >> testVerifyNumberOfTransitionsOfSIRExampleIs2 [ 
+	<gtExample>
+	|sirExample|
+	sirExample := KModel new.
+	sirExample 
+		attribute: #(status -> S I R);
+		parameters: #(beta lambda gamma mu);
+		transitions: #(
+			S -- lambda --> I.
+			I -- gamma --> R.);
+		lambda: #(beta*I/N).
+
+	self assert: (sirExample allTransitions size) equals: 2.
+	^sirExample 
+]


### PR DESCRIPTION
The transitions of the basic SIR model with the DSL are given by:

```Smalltalk
transitions: #(
			S -- lambda --> I.
			I -- gamma --> R.)
```

We check that the number of transitions of the basic SIR model is 2