### PR TITLE
We check that we return the transitions of the basic SIR model

### DIFF
--- a/src/Kendrick-Tests/DSLExamples.class.st
+++ b/src/Kendrick-Tests/DSLExamples.class.st
@@ -39,3 +39,26 @@ DSLExamples >> testAtAttributeOfSIRExample [
 	self assert: (sirExample atAttribute: #status) size equals: 3.
 	^sirExample 
 ]
+
+{ #category : #tests }
+DSLExamples >> testVerifyAllTransitionsOfSIRExample [
+	<gtExample>
+	|sirExample transtionsOfModel|
+	sirExample := KModel new.
+	sirExample 
+		attribute: #(status -> S I R);
+		parameters: #(beta lambda gamma mu);
+		transitions: #(
+			S -- lambda --> I.
+			I -- gamma --> R.);
+		lambda: #(beta*I/N).
+		
+		
+	transtionsOfModel := OrderedCollection new.
+	transtionsOfModel 
+			add: #S->#lambda->#I;
+		 	add: #I->#gamma->#R.
+		 
+	self assert: sirExample transitions equals: transtionsOfModel .
+	^sirExample
+]


### PR DESCRIPTION
For example with DSL, the basic SIR model transitions are:

```Smalltalk
transitions: #(
S -- lambda --> I.
I -- gamma --> R.)
```

We check from `transtions` that the returned transitions are equivalent to `transitionsOfModel`