### PR TITLE
Verify transitions of SIR model

### DIFF
--- a/src/Kendrick-Tests/DSLExamples.class.st
+++ b/src/Kendrick-Tests/DSLExamples.class.st
@@ -59,6 +59,29 @@ DSLExamples >> testVerifyAllStatesOfSIRExample [
 ]
 
 { #category : #tests }
+DSLExamples >> testVerifyAllTransitionsOfSIRExample [
+	<gtExample>
+	|sirExample transtionsOfModel|
+	sirExample := KModel new.
+	sirExample 
+		attribute: #(status -> S I R);
+		parameters: #(beta lambda gamma mu);
+		transitions: #(
+			S -- lambda --> I.
+			I -- gamma --> R.);
+		lambda: #(beta*I/N).
+		
+		
+	transtionsOfModel := OrderedCollection new.
+	transtionsOfModel 
+			add: #S->#lambda->#I;
+		 	add: #I->#gamma->#R.
+		 
+	self assert: sirExample transitions equals: transtionsOfModel .
+	^sirExample
+]
+
+{ #category : #tests }
 DSLExamples >> testVerifyNumberOfTransitionsOfSIRExampleIs2 [ 
 	<gtExample>
 	|sirExample|


### PR DESCRIPTION
For example with the DSL, the transitions of the basic SIR model are:

```Smalltalk
transitions: #(
			S -- lambda --> I.
			I -- gamma --> R.)
```

We check from the `transitions` that the transitions returned are equivalent to `transitionsOfmodel`